### PR TITLE
Update labelling based on current status

### DIFF
--- a/text/0001-github-issue-labels.md
+++ b/text/0001-github-issue-labels.md
@@ -71,28 +71,42 @@ We talked about using GitHub's Milestones as a way of defining a roadmap however
 
 There are 20 existing labels. While we're adding new labels, it makes sense to revisit the existing ones. Having a small, clearly defined set of labels makes it much more likely that the labelling system will be used. Here's what I propose should happen to each of them:
 
-| Label  | Destiny | Notes |
-|---|---|---|
+| Label | Destiny | Notes |
+|------------------------------------|---------|--------------------------------------------------------------------------------------------------------------------------|
 | API/Plugins | ❌delete | too specific (currently applied to 66 issues) |
-| bug | ✅keep |  rename to `type: bug` or similar |
-| Documentation | ✅keep | rename to `type: documentation` or similar |
-| DX | ❌delete |  too specific (currently applied to 13 issues) |
-| Feature Request | ✅keep | rename to `type: feature` or similar |
+| bug | ✍️rename | rename to `type: bug` or similar |
+| blogpost | ✍️rename | rename to `topic: blogpost` |
+| breaking change | ✅keep | It's a breaking change, might be consideration for the next major |
+| Documentation | ✍️rename | rename to `type: documentation` or similar |
+| DX | ❌delete | too specific (currently applied to 13 issues) |
+| Feature Request | ✍️rename | rename to `type: feature or enhancement` or similar |
 | good first issue | ✅keep | exact name is used by GitHub, don't rename |
 | GraphQL | ❌delete | too specific (currently applied to 13 issues) |
-| Hacktoberfest | ✅keep | exact name is used by Hacktoberfest, don't rename  |
-| Help Wanted for Plugins | ❌delete |  too specific (currently applied to 4 issues) |
-| Help Wanted in Core | ✅keep | rename to `help wanted` exact name is used by GitHub, don't rename |
-| needs-repro | ✅keep | rename to `needs repro` or similar |
+| Hacktoberfest | ✅keep | exact name is used by Hacktoberfest, don't rename |
+| Help Wanted for Plugins | ❌delete | too specific (currently applied to 4 issues) |
+| Help Wanted in Core | ✍️rename | rename to `help wanted` exact name is used by GitHub, don't rename |
+| needs-repro | ✍️rename | rename to `status: needs reproduction` or similar |
+| no triage | ✅keep | rename to something that's more descriptive. We could also use `status: confirmed` |
 | performance | ❌delete | too specific (currently applied to 4 issues) |
-| question | ✅keep | rename to `type: question or discussion` or similar |
+| question | ✍️rename | rename to `type: question or discussion` or similar |
 | review | ❌delete | ~~~Used by wafflebot? Investigate this~~~ No longer used |
-| stale? |  ✅keep | Used by stalebot to close stale issues. Maybe rename to `bot: stale?` |
-| upstream-issue | ❌delete | I'm 50/50 on this one. There's only two issues using it so have opted to delete it |
-| UX Design | ❌delete | redundant - add all issues with this label to the 'UX' project before deleting the label |
+| stale? | ✅keep | Used by stalebot to close stale issues. Maybe rename to `bot: stale?` |
+| status: assigned | ➕added | Mark issues as claimed for non contributors that can't use the assigned field in github |
+| status: awaiting author response | ➕added | Additional information or changes have been requested from the author |
+| status: awaiting reviewer response | ➕added | A pull request that is currently awaiting a reviewer's response |
+| status: blocked | ➕added | Issue or pull request that can't be resolved at the moment |
+| status: confirmed | ➕added | Issue with steps to reproduce the bug that’s been verified by at least one reviewer |
+| status: duplicate | ❌delete | we're not using it as we just close and refer the issue to the original one so we can still keep track of all duplicates |
+| status: inkteam to review | ✍️rename | rename to something that's more descriptive |
+| status: needs more info | ➕added | Needs triaging and more information to be resolved |
+| status: wip | ➕added | Work in progress ... inputs welcome! ❤️ |
+| upstream-issue | ✍️rename | Rename to `type: upstream` as it indicates an issue out of our control |
+| themes | ✍️rename | rename to `topic: themes` |
+| UX Design | ✍️rename | rename to `type: design` |
+| type: maintenance | ➕added | maintenance work that needs to be done, updating packages, tests, ... |
 | v0 | ❌delete | it's never been used |
-| v1  | ❌delete | We _could_ keep this but I don't think it adds much value (currently applied to 8 issues) |
-| v2  | ❌delete | redundant - add all issues with this label to the 'v2' project before deleting the label (currently applied to 7 issues) |
+| v1 | ❌delete | We _could_ keep this but I don't think it adds much value (currently applied to 8 issues) |
+| v2 | ❌delete | redundant - add all issues with this label to the 'v2' project before deleting the label (currently applied to 7 issues) |
 
 ### Implementation steps
 
@@ -136,3 +150,5 @@ A few approaches:
 # Unresolved questions
 
 - Do we need to create any additional projects to assign issues to?
+- Do we need to mark priorities? (can github projects help with ordering?)
+- Do we want to mark difficulty or complexity to bugs and features making community contribution *easier*?

--- a/text/0001-github-issue-labels.md
+++ b/text/0001-github-issue-labels.md
@@ -89,10 +89,14 @@ There are 20 existing labels. While we're adding new labels, it makes sense to r
 
 ### Implementation steps
 
-- [ ] collate any feedback on this RFC
-- [ ] for 'redundant' labels, add their issues to the appropriate projects
-- [ ] rename, delete and add labels
-- [ ] start labelling up _new_ and _recently updated_ issues
+- [x] collate any feedback on this RFC
+- [x] for 'redundant' labels, add their issues to the appropriate projects
+- [x] rename, delete and add labels
+- [x] start labelling up _new_ and _recently updated_ issues
+
+### Labels after implementing this RFC
+
+See [Gatsby's labels list](https://github.com/gatsbyjs/gatsby/labels) for the live list of labels.
 
 # Drawbacks
 
@@ -121,8 +125,6 @@ A few approaches:
 - Posting to the [Gatsby core maintainers discussion board](https://github.com/orgs/gatsbyjs/teams/gatsby-core-maintainers)
 - Adding label descriptions to [GitHub's labels page](https://github.com/gatsbyjs/gatsby/labels)
 - Adding labelling info to [CONTRIBUTING.MD](https://github.com/gatsbyjs/gatsby/blob/master/CONTRIBUTING.md)
-
-As a follow on from this, it'd be interesting to explore automated contributor onboarding. See https://github.com/styled-components/styled-components/blob/master/CONTRIBUTING.md#ownership for a good example.
 
 # Unresolved questions
 

--- a/text/0001-github-issue-labels.md
+++ b/text/0001-github-issue-labels.md
@@ -4,13 +4,13 @@
 
 # Summary
 
-Implement a labelling system for [issues on Gatsby's GitHub repo](https://github.com/gatsbyjs/gatsby/issues). This is following up from discussion at the recent Gatsby Maintainer Summit.
+Implement a labelling system for [issues on Gatsby's GitHub repo](https://github.com/gatsbyjs/gatsby/issues) and [pull requests on Gatsby's Github repo](https://github.com/gatsbyjs/gatsby/pulls). This is following up from discussion at the recent Gatsby Maintainer Summit.
 
 Refs https://github.com/gatsbyjs/gatsby/issues/4311
 
 # Motivation
 
-People _want_ to contribute to Gatsby, but with (currently) over 500 open issues it's difficult to know where to start.
+People _want_ to contribute to Gatsby, but with (currently) over 500 open issues and 120 pull requests it's difficult to know where to start.
 
 The aim is to make it easier for new and existing contributors to work on Gatsby without adding too much admin overhead. It's important for the labelling system to be quick to manage to ensure that it's used!
 
@@ -21,6 +21,7 @@ The broad areas discussed were:
 - Type: labels like `bug`, `discussion`, `feature request`
 - Status: labels like `needs repro`, `ready`
 - Misc: labels like `good first issue`
+- Topics: labels like `blogpost`, `themes`, `starters`
 - Target (area of responsibility): Use GitHub projects
 - Roadmap: Use GitHub Milestones
 
@@ -46,7 +47,13 @@ Optional
 
 So far these are labels indicating that an issue is a well-defined piece of work or labels used by bots.
 
-label: `good first issue`, `hacktober`, `stale?`, `review`
+label: `good first issue`, `help wanted`, `hacktober`, `stale?`, `review`
+
+### Topic label
+
+Optional
+
+labels: `topic: blogpost`, `topic: wordpress`, `topic: remark`, `topic: themes`
 
 ### Projects
 
@@ -75,10 +82,10 @@ There are 20 existing labels. While we're adding new labels, it makes sense to r
 | GraphQL | ❌delete | too specific (currently applied to 13 issues) |
 | Hacktoberfest | ✅keep | exact name is used by Hacktoberfest, don't rename  |
 | Help Wanted for Plugins | ❌delete |  too specific (currently applied to 4 issues) |
-| Help Wanted in Core | ✅keep | rename to `help wanted` or similar |
+| Help Wanted in Core | ✅keep | rename to `help wanted` exact name is used by GitHub, don't rename |
 | needs-repro | ✅keep | rename to `needs repro` or similar |
 | performance | ❌delete | too specific (currently applied to 4 issues) |
-| question | ✅keep | rename to `type: discussion` or similar |
+| question | ✅keep | rename to `type: question or discussion` or similar |
 | review | ❌delete | ~~~Used by wafflebot? Investigate this~~~ No longer used |
 | stale? |  ✅keep | Used by stalebot to close stale issues. Maybe rename to `bot: stale?` |
 | upstream-issue | ❌delete | I'm 50/50 on this one. There's only two issues using it so have opted to delete it |
@@ -129,4 +136,3 @@ A few approaches:
 # Unresolved questions
 
 - Do we need to create any additional projects to assign issues to?
-


### PR DESCRIPTION
Minor updates, but also an opportunity to add some questions.

- should we drop emojis from the label names? They look great but make it difficult to type the label names. This is mainly an issue when trying to manually apply a label filter in the issues list:

  e.g. [this returns 0 results because the emoji is missing](https://github.com/gatsbyjs/gatsby/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22type%3A+bug%22)
  
  ![screen shot 2018-07-26 at 13 01 33](https://user-images.githubusercontent.com/381801/43261315-2656b358-90d4-11e8-9c21-d77b9130e75f.png)

- I've added [a contributor guide to using labels on Gatsby's GitHub repo](https://github.com/gatsbyjs/gatsby/pull/6772/files). Comments welcome!

- I'd like to add a `status: confirmed` label, this would be used when bugs or features are confirmed and means that anyone could work on fixing the bug or implementing the feature. Also mentioned in the [contributor guide](https://github.com/gatsbyjs/gatsby/blob/14e99bae11daed60592c11e2fbf90e67e86d6f01/docs/docs/labelling-issues.md).

- A few new labels have been added recently. Can these be rolled into existing labels or updated to match the existing naming conventions?

  The new labels are `design`, `enhancement`, `Epic`, `💡 Proposed Work`

  `design` could be changed to `type: design`

  `enhancement` could be merged with `type: feature` to become `type: feature or enhancement`

  `Epic` I think is added automatically by ZenHub? I guess we can't do anything with this

  `💡 Proposed Work` is this ZenHub too? Can it be replaced with `type: feature or enhancement`?
