### PR TITLE
Fix spelling of "Gatsby" :)

### DIFF
--- a/text/0000-native-graphql-source.md
+++ b/text/0000-native-graphql-source.md
@@ -4,7 +4,7 @@
 
 # Summary
 
-This RFCs proposes the way to add third-party GraphQL schemas into Gatsby core schema. In addition to a low-level API to add schemas to be stitched, it describes a higher-level API/plugin to integrate third-party APIs into your Gatbsy API.
+This RFCs proposes the way to add third-party GraphQL schemas into Gatsby core schema. In addition to a low-level API to add schemas to be stitched, it describes a higher-level API/plugin to integrate third-party APIs into your Gatsby API.
 
 * [Implementation](https://github.com/gatsbyjs/gatsby/tree/graphql/schema-stitching)
 * [Simple example project](https://github.com/freiksenet/gatsby-github-displayer)
@@ -95,7 +95,7 @@ exports.sourceNodes = async ({ boundActionCreators }) => {
 
 # Motivation
 
-When Gatsby started, there weren't that many GraphQL APIs in the wild. Nowadays, not only there are many public GraphQL APIs, but also many people have their own internal GraphQL API. Tools like Prisma and AWS Appsync are increasingly popular. As Gastby uses GraphQL, it's weird that there is no native way to use those plugin schemas. Currently one needs to create a custom source plugin for every GraphQL API.
+When Gatsby started, there weren't that many GraphQL APIs in the wild. Nowadays, not only there are many public GraphQL APIs, but also many people have their own internal GraphQL API. Tools like Prisma and AWS Appsync are increasingly popular. As Gatsby uses GraphQL, it's weird that there is no native way to use those plugin schemas. Currently one needs to create a custom source plugin for every GraphQL API.
 
 This RFCs proposes the way to automatically merge Gatsby schema with third-party APIs. In addition, it provides a simple to use plugin to do that, that should cover most of the use cases.
 


### PR DESCRIPTION
It shouldn't really be necessary, but because of @gatsbot's insistence I'll elaborate :)

## Background

* The name of the Gatsby project is hard to spell when you're in a hurry, possibly because of the three consequtive consonants
* There are several cases of [funny](https://www.google.dk/search?q=gastby+site:gatsbyjs.org&nfpr=1) [misspellings](https://www.google.dk/search?q=gatbsy+site:gatsbyjs.org&nfpr=1) of Gatsby on gatsby.org

## Motivation

It's nicer to read texts that don't have too many spelling mistakes

## What this change does

Corrects two misspellings of Gatsby in one document.

## Possible follow-ups

I suggest doing a sweep through all the documentation and website. Maybe @gatsbot could be taught to recognize the common misspellings so it could give actually useful feedback on PRs? :smirk_cat: