### PR TITLE
feat: add contributing docs re-organization

### DIFF
--- a/text/docs-code-contributions.md
+++ b/text/docs-code-contributions.md
@@ -28,10 +28,11 @@ Contributing
     - How to file an issue
     - How to label an issue
     - Free swag for contributors
-    - Contributing to the repo
-        - page includes moved content from "How to contribute" incl. starter library, website, everything that isn't docs (with a mention of plugins section).
     - Contributing to the documentation
         - Docs templates
+    - Contributing to the repo
+        - page includes moved content from "How to contribute" incl. starter library, website, everything that isn't docs (with a mention of plugins section).
+    - Setting up test environments (Wordpress, Contentful, etc.)
 - RFC process
 - Submit to Site Showcase
 - Submit to Creator Showcase

--- a/text/docs-code-contributions.md
+++ b/text/docs-code-contributions.md
@@ -1,0 +1,58 @@
+- Start Date: 2019-02-07)
+- RFC PR: 
+- Gatsby Issue:
+
+# Summary
+
+Reorganize the contributor documentation to aid in Gatsby core and docs development.
+
+# Motivation
+
+The Gatsby.js docs, while wonderful, are light on coding instructions for contributors. With dedicated sections in the Contributing docs, it will be easier to learn how to clone the repository, where to find certain things like docs or plugins, how to run tests, and insider infrastructure knowledge required to submit a successful pull request on the first try.
+
+A lot of this information already lives on the "How to Contribute" page, but it's buried. It would help discoverability if this information lived on separate pages.
+
+# Detailed design
+
+I propose that we add some pages to the existing contributor documentation and move some content around. Here is an IA diagram that (briefly) reflects the current structure and what I think we should add (open for discussion, of course):
+
+Contributing
+- Community
+    - Pair Programming Sessions
+    - Where to participate in the community (this was in RFCs, perhaps it could be reintroduced and content moved from "How to contribute"?)
+    - How to run a Gatsby workshop*
+    - How to pitch Gatsby*
+- Code of Conduct
+- Gatsby Style Guide
+- How to contribute
+    - How to file an issue
+    - How to label an issue
+    - Free swag for contributors
+    - Contributing to the repo
+        - page includes moved content from "How to contribute" incl. starter library, website, everything that isn't docs (with a mention of plugins section).
+    - Contributing to the documentation
+        - Docs templates
+- RFC process
+- Submit to Site Showcase
+- Submit to Creator Showcase
+- Submit to Starter Library
+- Submit to Plugin Library
+
+# Drawbacks
+
+Why should we *not* do this? Please consider:
+
+- we will need some redirects so people who have bookmarked things don't get 404s
+- there will be a user adjustment required to learn the new locations of things
+
+# Alternatives
+
+Adding more top-level docs instead of reorganizing them. It's a pretty large section though, and it seems like it could be reorganized.
+
+# Adoption strategy
+
+If we implement this, I will move some pages and content around and fill in missing gaps. There may be additional subpages added for more detailed technical instructions.
+
+# Unresolved questions
+
+How do people feel about this idea? 

--- a/text/docs-code-contributions.md
+++ b/text/docs-code-contributions.md
@@ -16,28 +16,38 @@ A lot of this information already lives on the "How to Contribute" page, but it'
 
 I propose that we add some pages to the existing contributor documentation and move some content around. Here is an IA diagram that (briefly) reflects the current structure and what I think we should add (open for discussion, of course):
 
+Docs
+- Guides
+- Ecosystem
+- API Reference
+- Releases & Migration
+- Conceptual Guide
+- Behind the Scenes
+- Advanced Tutorials
+
 Contributing
 - Community
+    - Why contribute to Gatsby?
     - Pair Programming Sessions
-    - Where to participate in the community (this was in RFCs, perhaps it could be reintroduced and content moved from "How to contribute"?)
+    - Free swag for contributors
+    - Where to participate in the community
     - How to run a Gatsby workshop*
     - How to pitch Gatsby*
 - Code of Conduct
 - Gatsby Style Guide
 - How to contribute
-    - How to file an issue
-    - How to label an issue
-    - Free swag for contributors
-    - Contributing to the documentation
-        - Docs templates
-    - Contributing to the repo
-        - page includes moved content from "How to contribute" incl. starter library, website, everything that isn't docs (with a mention of plugins section).
-    - Setting up test environments (Wordpress, Contentful, etc.)
+    * Filing & Managing issues
+    * Managing pull requests
+    * Setting up your local dev environment
+    * Docs contributions
+    * Code contributions
+    * Community contributions
+    * Showcase contributions
+        - Submit to Site Showcase
+        - Submit to Creator Showcase
+        - Submit to Starter Library
+        - Submit to Plugin Library
 - RFC process
-- Submit to Site Showcase
-- Submit to Creator Showcase
-- Submit to Starter Library
-- Submit to Plugin Library
 
 # Drawbacks
 

--- a/text/docs-code-contributions.md
+++ b/text/docs-code-contributions.md
@@ -27,27 +27,28 @@ Docs
 
 Contributing
 - Community
-    - Why contribute to Gatsby?
+    - Why Contribute to Gatsby?
     - Pair Programming Sessions
-    - Free swag for contributors
-    - Where to participate in the community
-    - How to run a Gatsby workshop*
-    - How to pitch Gatsby*
+    - Free Swag for Contributors
+    - Where to Participate in the Community
+    - How to Run a Gatsby Workshop
+    - How to Pitch Gatsby
 - Code of Conduct
 - Gatsby Style Guide
-- How to contribute
-    * Filing & Managing issues
-    * Managing pull requests
-    * Setting up your local dev environment
-    * Docs contributions
-    * Code contributions
-    * Community contributions
-    * Showcase contributions
+- How to Contribute
+    * How to File an Issue
+    * How to Label an Issue
+    * Managing Issues and Pull Requests
+    * Setting up your Local Dev Environment
+    * Docs Contributions
+    * Code Contributions
+    * Community Contributions
         - Submit to Site Showcase
         - Submit to Creator Showcase
         - Submit to Starter Library
         - Submit to Plugin Library
-- RFC process
+- RFC Process
+- Gatsby's Governance Model*
 
 # Drawbacks
 

--- a/text/docs-code-contributions.md
+++ b/text/docs-code-contributions.md
@@ -38,7 +38,7 @@ Contributing
 - How to Contribute
     * How to File an Issue
     * How to Label an Issue
-    * Managing Issues and Pull Requests
+    * Triaging GitHub Issues
     * Setting up your Local Dev Environment
     * Docs Contributions
     * Code Contributions

--- a/text/docs-code-contributions.md
+++ b/text/docs-code-contributions.md
@@ -39,9 +39,10 @@ Contributing
     * How to File an Issue
     * How to Label an Issue
     * Triaging GitHub Issues
-    * Setting up your Local Dev Environment
     * Docs Contributions
+    * Blog & Website Contributions
     * Code Contributions
+    * Setting up your Local Dev Environment
     * Community Contributions
         - Submit to Site Showcase
         - Submit to Creator Showcase


### PR DESCRIPTION
The Gatsby.js docs, while wonderful, are light on coding instructions for contributors. With dedicated sections in the Contributing docs, it will be easier to learn how to clone the repository, where to find certain things like docs or plugins, how to run tests, and insider infrastructure knowledge required to submit a successful pull request on the first try.

A lot of this information already lives on the "How to Contribute" page, but it's buried. It would help discoverability if this information lived on separate pages. Doing this means we can easily add a new section on "Setting up test environments", such as using Docker to hook up an easy Wordpress test installation.

I would love to hear your feedback as this is my first Gatsby RFC. I'm totally open to suggestions!
