### PR TITLE
Avoid language that suggests implementations of an RFC should wait for it to be accepted

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ become 'active'.
 
 ## The RFC life-cycle
 
-Once an RFC becomes active, then authors may implement it and submit the
-feature as a pull request to the Gatsby repo. Becoming 'active' is not a rubber
+Once an RFC becomes active, then authors may submit a finished implementation of it
+as a pull request to the Gatsby repo. Becoming 'active' is not a rubber
 stamp, and in particular still does not mean the feature will ultimately be
 merged; it does mean that the core team has agreed to it in principle and are
 amenable to merging it.


### PR DESCRIPTION
It's often a good idea to prototype an implementation of an RFC while it's being deliberated as many designs can't be created without trying out the code.