### PR TITLE
Fix typos across rfcs repo

### DIFF
--- a/text/000-cli-redesign.md
+++ b/text/000-cli-redesign.md
@@ -59,7 +59,7 @@ The user can:
 - [x] enter shorter input for starter URL's (users can omit the https://www part of the starter URL)
 - [x] select a starter in the CLI without needing a URL. See PR https://github.com/gatsbyjs/gatsby/pull/14097
 - [ ] be redirected to the correct URL when typing in “localhost:8000/_ _ graphiql incorrectly (we could either redirect to "correct" one or just support multiple different cases)
-- [ ] mispell a Gatsby command and the CLI will run the correct command anyway just like Google search does when you mispell something (requires us to update the did-you-mean file). https://github.com/gatsbyjs/gatsby/issues/13512
+- [ ] misspell a Gatsby command and the CLI will run the correct command anyway just like Google search does when you misspell something (requires us to update the did-you-mean file). https://github.com/gatsbyjs/gatsby/issues/13512
 - [ ] get createPages page count in output to help users optimize for speed and catch errors faster''
 - [ ] get notified that they might need to hit `r` if they’ve changed package.json, gatsby node, etc. when `gatsby develop` is running
 - [ ] see only relevant warnings; e.g. omission of peer dependency warnings that they can ignore

--- a/text/0004-native-graphql-source.md
+++ b/text/0004-native-graphql-source.md
@@ -29,7 +29,7 @@ module.exports = {
         url: "https://api.graphcms.com/simple/v1/swapi",
       },
     },
-    // Passing paramaters (passed to apollo-link)
+    // Passing parameters (passed to apollo-link)
     {
       resolve: "gatsby-source-graphql",
       options: {

--- a/text/0006-node-8-minimum-version.md
+++ b/text/0006-node-8-minimum-version.md
@@ -113,7 +113,7 @@ We've internally discussed something called `gatsby doctor` which can be run pri
 
 This proposal requires documentation to be updated. Our documentation can be considered a code style-guide and oftentimes developers directly copy and paste from our documentation. If we are documenting what we think is a best practice (e.g. Node 6 features like async/await) we are implicitly easing the migration cost of any developer who reads our documentation--which is hopefully all of them!
 
-I strongly feel that tweaking the documentation, as well as minimum version requirements, will lead to developers having a _better_ experience using Gatsby, and Gatsby as a whole becomes easier to teach. It resolves the idiosyncracy of _why_ do I need a global install and _when_ do I use `async` / `await` or `return new Promise`. This change should have a net positive impact on the ease-of-use of teaching Gatsby to new and experienced developers, alike.
+I strongly feel that tweaking the documentation, as well as minimum version requirements, will lead to developers having a _better_ experience using Gatsby, and Gatsby as a whole becomes easier to teach. It resolves the idiosyncrasy of _why_ do I need a global install and _when_ do I use `async` / `await` or `return new Promise`. This change should have a net positive impact on the ease-of-use of teaching Gatsby to new and experienced developers, alike.
 
 # Unresolved questions
 


### PR DESCRIPTION
:writing_hand: **Fix typos across rfcs repo**

**Files that have typos**

```
rfcs/text/000-cli-redesign.md:62:6: "mispell" is a misspelling of "misspell"
rfcs/text/000-cli-redesign.md:62:117: "mispell" is a misspelling of "misspell"
rfcs/text/0004-native-graphql-source.md:32:15: "paramaters" is a misspelling of "parameters"
rfcs/text/0006-node-8-minimum-version.md:116:220: "idiosyncracy" is a misspelling of "idiosyncrasy"
```

**PS:** I use [**client9/misspell**](https://github.com/client9/misspell) to scan typos :heart: